### PR TITLE
Add Elastic environment variables to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Create a .env file in the root lib and add these tokens/secrets before running t
     DISCORD_APPLICATION_ID=
     DISCORD_TOKEN=
     DISCORD_SERVER_ID=
+    ELASTIC_NODE_URL=
+    ELASTIC_INDEX_NAME=
 
 ### Next steps / Tasks
 


### PR DESCRIPTION
Elastic variables have been added to the README since they are needed in the .env file.